### PR TITLE
Small improvements of install script and runoracle

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,27 +13,41 @@ do
     shift
 done
 
-sudo apt-get update
+read -p "Do you want to update? [y/N]? " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    sudo apt-get update
+fi
 sudo apt-get install python-dev vim screen
 sudo pip install -r requirements.txt
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 HOME="$DIR/.."
 
-wget --directory-prefix=$HOME https://bitcoin.org/bin/0.9.1/bitcoin-0.9.1-linux.tar.gz
-tar -C $HOME -zxvf $HOME/bitcoin-0.9.1-linux.tar.gz
-mv $HOME/bitcoin-0.9.1-linux $HOME/bitcoin
-rm $HOME/bitcoin-0.9.1-linux.tar.gz
 
-cp $DIR/src/settings_local.py.example $DIR/src/settings_local.py
+read -p "Do you need to install bitcoind? [y/N]? " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    wget --directory-prefix=$HOME https://bitcoin.org/bin/0.9.1/bitcoin-0.9.1-linux.tar.gz &&
+    tar -C $HOME -zxvf $HOME/bitcoin-0.9.1-linux.tar.gz &&
+    mv $HOME/bitcoin-0.9.1-linux $HOME/bitcoin &&
+    rm $HOME/bitcoin-0.9.1-linux.tar.gz &&
+    echo 'alias bitcoind=~/bitcoin/bin/64/bitcoin' >> $HOME/.bash_aliases &&
+    source $HOME/.bash_aliases &&
+    
+    cp $DIR/src/settings_local.py.example $DIR/src/settings_local.py
+fi
+
 
 if [ "$tflag" == "yes" ]
 then
   echo BITCOIND_TEST_MODE=True >> $DIR/src/settings_local.py
 fi
 
-
-mkdir $HOME/.bitcoin/
+mkdir -p $HOME/.bitcoin/
+# this is harmless even if the file exists
 touch $HOME/.bitcoin/bitcoin.conf
 
 BTCRPC=`openssl rand -hex 32`

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ then
     tar -C $HOME -zxvf $HOME/bitcoin-0.9.1-linux.tar.gz &&
     mv $HOME/bitcoin-0.9.1-linux $HOME/bitcoin &&
     rm $HOME/bitcoin-0.9.1-linux.tar.gz &&
-    echo 'alias bitcoind=~/bitcoin/bin/64/bitcoin' >> $HOME/.bash_aliases &&
+    echo 'alias bitcoind=~/bitcoin/bin/64/bitcoind' >> $HOME/.bash_aliases &&
     source $HOME/.bash_aliases &&
     
     cp $DIR/src/settings_local.py.example $DIR/src/settings_local.py

--- a/runoracle.sh
+++ b/runoracle.sh
@@ -7,6 +7,7 @@ HOME="$DIR/.."
 
 if [ -z $(pgrep bitcoind) ]
 then
+    export LC_ALL=C &&
     $HOME/bitcoin/bin/$(getconf LONG_BIT)/bitcoind -datadir=$HOME/.bitcoin/ -rpcport=2521 &
     sleep 2
 fi


### PR DESCRIPTION
When installing, long operations such as sudo apt-get update or re-downloading the bitcoind client are made optional. 
Furthermore, commands that used to break the flow when for instance ~/.bitcoin already existed don't do that anymore. 
Finally, a bug when launching bitcoind is fixed by setting the environment variable LC_ALL to C.
