### PR TITLE
Bitcoin binary download url is fixed.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ sudo pip install -r requirements.txt
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 HOME="$DIR/.."
 
-wget --directory-prefix=$HOME https://bitcoin.org/bin/0.9.1/bitcoin-0.9.1-linux.tar.gz
+wget --directory-prefix=$HOME https://bitcoin.org/bin/bitcoin-core-0.9.1/bitcoin-0.9.1-linux.tar.gz
 tar -C $HOME -zxvf $HOME/bitcoin-0.9.1-linux.tar.gz
 mv $HOME/bitcoin-0.9.1-linux $HOME/bitcoin
 rm $HOME/bitcoin-0.9.1-linux.tar.gz


### PR DESCRIPTION
Bitcoin binary download url has been changed which has been causing installation failure. After changing the url to the current one(https://bitcoin.org/bin/bitcoin-core-0.9.1), I have been able to install orisi without any issue.
